### PR TITLE
Add HLStrippableRegistry to HeccoLib

### DIFF
--- a/common/src/main/java/net/hecco/heccolib/HeccoLib.java
+++ b/common/src/main/java/net/hecco/heccolib/HeccoLib.java
@@ -1,5 +1,7 @@
 package net.hecco.heccolib;
 
+import net.hecco.heccolib.lib.strippable.HLStrippableRegistry;
+import net.minecraft.world.level.block.Blocks;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/common/src/main/java/net/hecco/heccolib/lib/strippable/HLStrippableRegistry.java
+++ b/common/src/main/java/net/hecco/heccolib/lib/strippable/HLStrippableRegistry.java
@@ -1,0 +1,37 @@
+package net.hecco.heccolib.lib.strippable;
+
+import net.hecco.heccolib.HeccoLib;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.RotatedPillarBlock;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class HLStrippableRegistry {
+    private static final Map<Block, Block> LOGS = new LinkedHashMap<>();
+
+    public static void add(Block log, Block stripped) {
+        boolean noLogAxis = !log.defaultBlockState().hasProperty(RotatedPillarBlock.AXIS);
+        boolean noStripAxis = !stripped.defaultBlockState().hasProperty(RotatedPillarBlock.AXIS);
+
+        if (noLogAxis || noStripAxis) {
+            String output;
+            if (noLogAxis && noStripAxis) output = "both";
+            else output = (noLogAxis) ? log.toString() : stripped.toString();
+
+            HeccoLib.LOGGER.error("Could not register axe stripping behavior for {} and {} due to a missing axis property in {}!", log, stripped, output);
+        }
+        else {
+            LOGS.put(log, stripped);
+        }
+    }
+
+    public static void add(Supplier<Block> log, Supplier<Block> stripped) {
+        add(log.get(), stripped.get());
+    }
+
+    public static Map<Block, Block> getStrippables() { return LOGS; }
+}

--- a/common/src/main/java/net/hecco/heccolib/mixin/AxeItemMixin.java
+++ b/common/src/main/java/net/hecco/heccolib/mixin/AxeItemMixin.java
@@ -1,0 +1,33 @@
+package net.hecco.heccolib.mixin;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import net.hecco.heccolib.lib.strippable.HLStrippableRegistry;
+import net.minecraft.world.item.AxeItem;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.RotatedPillarBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Mixin(AxeItem.class)
+public class AxeItemMixin {
+    // thanks neoforge for having events for literally everything but good content - artyrian
+    @ModifyVariable(method = "evaluateNewBlockState", at = @At("STORE"), ordinal = 0)
+    private Optional<BlockState> tryWrapWithHLBlocks(Optional<BlockState> value, @Local(argsOnly = true) BlockState state) {
+        if (value.isEmpty()) {
+            Map<Block, Block> STRIPS_2 = HLStrippableRegistry.getStrippables();
+
+            Optional<BlockState> stripgrab = Optional.ofNullable(STRIPS_2.get(state.getBlock())).map((block) -> {
+                return block.defaultBlockState().setValue(RotatedPillarBlock.AXIS, state.getValue(RotatedPillarBlock.AXIS));
+            });
+
+            if (stripgrab.isPresent()) return stripgrab;
+        }
+
+        return value;
+    }
+}

--- a/common/src/main/resources/heccolib.mixins.json
+++ b/common/src/main/resources/heccolib.mixins.json
@@ -6,6 +6,7 @@
   "compatibilityLevel": "JAVA_18",
   "mixins": [
     "AbstractFurnaceBlockEntityMixin",
+    "AxeItemMixin",
     "FireBlockSetFlammableInvoker"
   ],
   "client": [


### PR DESCRIPTION
This PR simply adds an axe-strippables reg to HeccoLib, aptly named `HLStrippableRegistry`. It's solely mixin-based, therefore it doesn't rely on anything done by either modloader - and to my knowledge, should seamlessly integrate with actual modloader events.
(well, not that neoforge has a strippable event anyway, thanks neoforge i would like 30 more niche and useless events please)

Adding blocks to the registry should be relatively straightforward and simple. As this was made with the ML port of Bountiful Fares in mind, I'll use those as an example:
```
HLStrippableRegistry.add(BFBlocks.HOARY_LOG, BFBlocks.STRIPPED_HOARY_LOG);
HLStrippableRegistry.add(BFBlocks.HOARY_WOOD, BFBlocks.STRIPPED_HOARY_WOOD);
HLStrippableRegistry.add(BFBlocks.WALNUT_LOG, BFBlocks.STRIPPED_WALNUT_LOG);
HLStrippableRegistry.add(BFBlocks.WALNUT_WOOD, BFBlocks.STRIPPED_WALNUT_WOOD);
```

This will register the following logs & their stripped variants into HeccoLib's new stripping registry, which will be injected directly into the strip check in the `AxeItem` itself. This means these logs will obey the usual rules, i.e. damaging the axe, failing when using a shield, (probably) working with modded `AxeItem`s, etc.

<img width="896" height="528" alt="image" src="https://github.com/user-attachments/assets/41897d58-151c-42a4-8714-dac69ae2b2e4" />