### PR TITLE
Shovel Pathing Registry, HLPathableRegistry

### DIFF
--- a/common/src/main/java/net/hecco/heccolib/HeccoLib.java
+++ b/common/src/main/java/net/hecco/heccolib/HeccoLib.java
@@ -1,7 +1,5 @@
 package net.hecco.heccolib;
 
-import net.hecco.heccolib.lib.strippable.HLStrippableRegistry;
-import net.minecraft.world.level.block.Blocks;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/common/src/main/java/net/hecco/heccolib/lib/pathable/HLPathableRegistry.java
+++ b/common/src/main/java/net/hecco/heccolib/lib/pathable/HLPathableRegistry.java
@@ -1,0 +1,22 @@
+package net.hecco.heccolib.lib.pathable;
+
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class HLPathableRegistry {
+    private static final Map<Block, BlockState> PATHS = new LinkedHashMap<>();
+
+    public static void add(Block block, Block path) {
+        PATHS.put(block, path.defaultBlockState());
+    }
+
+    public static void add(Supplier<Block> block, Supplier<Block> path) {
+        add(block.get(), path.get());
+    }
+
+    public static Map<Block, BlockState> getPathables() { return PATHS; }
+}

--- a/common/src/main/java/net/hecco/heccolib/mixin/ShovelItemMixin.java
+++ b/common/src/main/java/net/hecco/heccolib/mixin/ShovelItemMixin.java
@@ -1,0 +1,36 @@
+package net.hecco.heccolib.mixin;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import net.hecco.heccolib.lib.pathable.HLPathableRegistry;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.item.ShovelItem;
+import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Mixin(ShovelItem.class)
+public class ShovelItemMixin {
+    // If this breaks contact Artyrian
+    @ModifyVariable(method = "useOn", at = @At(value = "STORE"), ordinal = 1)
+    public BlockState tryHLPathable(BlockState oldValue, @Local(argsOnly = true) UseOnContext context) {
+        if (oldValue == null) {
+            Level level = context.getLevel();
+            BlockPos blockpos = context.getClickedPos();
+            BlockState blockstate = level.getBlockState(blockpos);
+            Block block = blockstate.getBlock();
+
+            Map<Block, BlockState> PATHS_2 = HLPathableRegistry.getPathables();
+            Optional<BlockState> possibleState = Optional.ofNullable(PATHS_2.get(block));
+
+            if (possibleState.isPresent()) return possibleState.get();
+        }
+        return oldValue;
+    }
+}

--- a/common/src/main/resources/heccolib.mixins.json
+++ b/common/src/main/resources/heccolib.mixins.json
@@ -7,7 +7,8 @@
   "mixins": [
     "AbstractFurnaceBlockEntityMixin",
     "AxeItemMixin",
-    "FireBlockSetFlammableInvoker"
+    "FireBlockSetFlammableInvoker",
+    "ShovelItemMixin"
   ],
   "client": [
     "AbstractClientPlayerMixin"


### PR DESCRIPTION
A simple registry for adding shovel pathing, `HLPathableRegistry`. Completely seperate from modloader events/utilities, and solely mixin-based. For an example, adding new pathable blocks is as simple as:
```
HLPathableRegistry.add(Blocks.EMERALD_BLOCK, Blocks.DIRT_PATH);
```
The "dirt" and "path" blocks can be any of your choice.
![java_8XCImbpmsC](https://github.com/user-attachments/assets/886d4489-3569-480d-9272-e231a0b42fd6)
